### PR TITLE
fix: custom cleanup and allocation duration is not needed

### DIFF
--- a/test/integ/allocate/integ.allocate.ts.snapshot/asset.32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382/index.js
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/asset.32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382/index.js
@@ -11864,7 +11864,7 @@ var Logger = class {
 };
 
 // src/allocate/allocate.lambda.ts
-var MAX_ALLOCATION_DURATION_SECONDS = 60 * 60;
+var ALLOCATION_DURATION_SECONDS = 60 * 60;
 var ProxyError = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -11894,11 +11894,7 @@ async function safeDoHandler(allocationId, request, log) {
   }
 }
 async function doHandler(allocationId, request, log) {
-  const durationSeconds = request.durationSeconds ?? MAX_ALLOCATION_DURATION_SECONDS;
-  if (durationSeconds > MAX_ALLOCATION_DURATION_SECONDS) {
-    throw new ProxyError(400, `Maximum allocation duration is ${MAX_ALLOCATION_DURATION_SECONDS} seconds`);
-  }
-  const timeoutDate = new Date(Date.now() + 1e3 * durationSeconds);
+  const timeoutDate = new Date(Date.now() + 1e3 * ALLOCATION_DURATION_SECONDS);
   log.info(`Acquiring environment from pool '${request.pool}'`);
   const environment = await acquireEnvironment(allocationId, request.pool);
   log.info(`Starting allocation of 'aws://${environment.account}/${environment.region}'`);
@@ -11906,7 +11902,7 @@ async function doHandler(allocationId, request, log) {
   log.info(`Grabbing credentials to aws://${environment.account}/${environment.region} using role: ${environment.adminRoleArn}`);
   const credentials = await grabCredentials(allocationId, environment);
   log.info("Allocation started successfully");
-  const response = { id: allocationId, environment, credentials, durationSeconds };
+  const response = { id: allocationId, environment, credentials };
   log.info(`Scheduling allocation timeout to ${timeoutDate}`);
   await clients.scheduler.scheduleAllocationTimeout({
     allocationId,
@@ -12254,7 +12250,7 @@ if (require.main !== module) {
 }
 
 // src/deallocate/deallocate.lambda.ts
-var MAX_CLEANUP_TIMEOUT_SECONDS = 60 * 60;
+var CLEANUP_TIMEOUT_SECONDS = 60 * 60;
 var ProxyError2 = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -12285,11 +12281,7 @@ async function safeDoHandler2(allocationId, request, log) {
 }
 async function doHandler3(allocationId, request, log) {
   try {
-    const cleanupDurationSeconds = request.cleanupDurationSeconds ?? MAX_CLEANUP_TIMEOUT_SECONDS;
-    if (cleanupDurationSeconds > MAX_CLEANUP_TIMEOUT_SECONDS) {
-      throw new ProxyError2(400, `Maximum cleanup timeout is ${MAX_CLEANUP_TIMEOUT_SECONDS} seconds`);
-    }
-    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * cleanupDurationSeconds);
+    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * CLEANUP_TIMEOUT_SECONDS);
     log.info(`Ending allocation with outcome: ${request.outcome}`);
     const allocation = await endAllocation(allocationId, request.outcome);
     log.info(`Scheduling timeout for cleanup of environment 'aws://${allocation.account}/${allocation.region}' to ${cleanupTimeoutDate}`);
@@ -12302,13 +12294,13 @@ async function doHandler3(allocationId, request, log) {
     });
     log.info(`Starting cleanup of 'aws://${allocation.account}/${allocation.region}'`);
     await clients3.environments.cleaning(allocationId, allocation.account, allocation.region);
-    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: cleanupDurationSeconds });
+    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: CLEANUP_TIMEOUT_SECONDS });
     log.info(`Successfully started cleanup task: ${taskInstanceArn}`);
-    return success2({ cleanupDurationSeconds });
+    return success2();
   } catch (e) {
     if (e instanceof AllocationAlreadyEndedError) {
       log.info(`Returning success because: ${e.message}`);
-      return success2({ cleanupDurationSeconds: -1 });
+      return success2();
     }
     throw e;
   }
@@ -12337,8 +12329,8 @@ async function endAllocation(id, outcome) {
     throw e;
   }
 }
-function success2(body) {
-  return { statusCode: 200, body: JSON.stringify(body) };
+function success2() {
+  return { statusCode: 200, body: JSON.stringify({}) };
 }
 function failure2(e) {
   const statusCode = e instanceof ProxyError2 ? e.statusCode : 500;

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.assets.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "4c61a8eae045cde55e413d8ab9df35252b808d833859c537a07c3944667df2bd": {
+    "32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382": {
       "source": {
-        "path": "asset.4c61a8eae045cde55e413d8ab9df35252b808d833859c537a07c3944667df2bd",
+        "path": "asset.32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4c61a8eae045cde55e413d8ab9df35252b808d833859c537a07c3944667df2bd.zip",
+          "objectKey": "32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "c0bc01486067091414712d7669ed526a55f6abd15764e88601c38c75f1b7dda2": {
+    "3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac": {
       "source": {
         "path": "atmosphere-integ-allocate-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c0bc01486067091414712d7669ed526a55f6abd15764e88601c38c75f1b7dda2.json",
+          "objectKey": "3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.template.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.template.json
@@ -50,7 +50,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "4c61a8eae045cde55e413d8ab9df35252b808d833859c537a07c3944667df2bd.zip"
+     "S3Key": "32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382.zip"
     },
     "Description": "test/integ/allocate/assert.lambda.ts",
     "Environment": {
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682524493"
+    "salt": "1738692955183"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.assets.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "e28f7e526d039a0139162e4baede87c3a3152f7451e3c20c3f772ec268ee43c2": {
+    "50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94": {
       "source": {
         "path": "atmosphere-integ-allocate.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e28f7e526d039a0139162e4baede87c3a3152f7451e3c20c3f772ec268ee43c2.json",
+          "objectKey": "50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.template.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/allocate/integ.allocate.ts.snapshot/manifest.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/e28f7e526d039a0139162e4baede87c3a3152f7451e3c20c3f772ec268ee43c2.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -571,15 +571,6 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
-        ],
-        "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995",
-            "trace": [
-              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
-            ]
-          }
         ]
       },
       "displayName": "atmosphere-integ-allocate"
@@ -601,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/c0bc01486067091414712d7669ed526a55f6abd15764e88601c38c75f1b7dda2.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/allocate/integ.allocate.ts.snapshot/tree.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.3]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.3]}eu-central-1",
-                    "path": "atmosphere-integ-allocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.3]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-allocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.3]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.3]}eu-central-1",
-                    "path": "atmosphere-integ-allocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.3]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-allocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3895,7 +3895,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "4c61a8eae045cde55e413d8ab9df35252b808d833859c537a07c3944667df2bd.zip"
+                      "s3Key": "32f9cbdd00c906811ccd5dca4625101aea15507dff070c9f62ba42260a07d382.zip"
                     },
                     "description": "test/integ/allocate/assert.lambda.ts",
                     "environment": {

--- a/test/integ/allocation-timeout/assert.lambda.ts
+++ b/test/integ/allocation-timeout/assert.lambda.ts
@@ -18,7 +18,7 @@ export async function handler(_: any) {
   });
 
   await Runner.assert('no-ops-if-allocation-has-ended', async (session: Runner) => {
-    const response = await session.runtime.allocate({ pool: 'release', requester: 'test', durationSeconds: 30 } );
+    const response = await session.runtime.allocate({ pool: 'release', requester: 'test' } );
     const body = JSON.parse(response.body!);
 
     await clients.allocations.end({ id: body.id, outcome: 'success' });

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.assets.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "f7c9ba9c09256fb21b84455d5f4942440c7adcf0410249ab135486fa7b45fb21": {
+    "46cecadeeb59a2eeb65cd33091908eefbd4343f1b9eaff55beb3e00a05eaf49e": {
       "source": {
-        "path": "asset.f7c9ba9c09256fb21b84455d5f4942440c7adcf0410249ab135486fa7b45fb21",
+        "path": "asset.46cecadeeb59a2eeb65cd33091908eefbd4343f1b9eaff55beb3e00a05eaf49e",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f7c9ba9c09256fb21b84455d5f4942440c7adcf0410249ab135486fa7b45fb21.zip",
+          "objectKey": "46cecadeeb59a2eeb65cd33091908eefbd4343f1b9eaff55beb3e00a05eaf49e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "8f00ae7a9be30265bab9f9397e07b69ac1a8c2d6526474b7ddecf41e5750a821": {
+    "52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3": {
       "source": {
         "path": "atmosphere-integ-allocation-timeout-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8f00ae7a9be30265bab9f9397e07b69ac1a8c2d6526474b7ddecf41e5750a821.json",
+          "objectKey": "52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.template.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.template.json
@@ -50,7 +50,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f7c9ba9c09256fb21b84455d5f4942440c7adcf0410249ab135486fa7b45fb21.zip"
+     "S3Key": "46cecadeeb59a2eeb65cd33091908eefbd4343f1b9eaff55beb3e00a05eaf49e.zip"
     },
     "Description": "test/integ/allocation-timeout/assert.lambda.ts",
     "Environment": {
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682524492"
+    "salt": "1738692955183"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.assets.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "b25da9e8d00ce5292dc486fac66486e56127671f263d521524d4ea8ce670da56": {
+    "0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb": {
       "source": {
         "path": "atmosphere-integ-allocation-timeout.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b25da9e8d00ce5292dc486fac66486e56127671f263d521524d4ea8ce670da56.json",
+          "objectKey": "0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.template.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/manifest.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b25da9e8d00ce5292dc486fac66486e56127671f263d521524d4ea8ce670da56.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -571,15 +571,6 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
-        ],
-        "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995",
-            "trace": [
-              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
-            ]
-          }
         ]
       },
       "displayName": "atmosphere-integ-allocation-timeout"
@@ -601,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/8f00ae7a9be30265bab9f9397e07b69ac1a8c2d6526474b7ddecf41e5750a821.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/tree.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
-                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
-                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3895,7 +3895,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "f7c9ba9c09256fb21b84455d5f4942440c7adcf0410249ab135486fa7b45fb21.zip"
+                      "s3Key": "46cecadeeb59a2eeb65cd33091908eefbd4343f1b9eaff55beb3e00a05eaf49e.zip"
                     },
                     "description": "test/integ/allocation-timeout/assert.lambda.ts",
                     "environment": {

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/asset.f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7/index.js
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/asset.f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7/index.js
@@ -7334,7 +7334,7 @@ var require_finally = __commonJS({
       function succeed() {
         return finallyHandler.call(this, this.promise._target()._settledValue());
       }
-      function fail(reason) {
+      function fail2(reason) {
         if (checkCancel(this, reason)) return;
         errorObj2.e = reason;
         return errorObj2;
@@ -7365,7 +7365,7 @@ var require_finally = __commonJS({
               }
               return maybePromise._then(
                 succeed,
-                fail,
+                fail2,
                 void 0,
                 this,
                 void 0
@@ -7382,11 +7382,11 @@ var require_finally = __commonJS({
           return reasonOrValue;
         }
       }
-      Promise2.prototype._passThrough = function(handler7, type, success3, fail2) {
+      Promise2.prototype._passThrough = function(handler7, type, success3, fail3) {
         if (typeof handler7 !== "function") return this.then();
         return this._then(
           success3,
-          fail2,
+          fail3,
           void 0,
           new PassThroughHandlerContext(this, type, handler7),
           void 0
@@ -11207,7 +11207,7 @@ var require_lib2 = __commonJS({
   }
 });
 
-// test/integ/deallocate/assert.lambda.ts
+// test/integ/cleanup-timeout/assert.lambda.ts
 var assert_lambda_exports = {};
 __export(assert_lambda_exports, {
   handler: () => handler6
@@ -11864,7 +11864,7 @@ var Logger = class {
 };
 
 // src/allocate/allocate.lambda.ts
-var MAX_ALLOCATION_DURATION_SECONDS = 60 * 60;
+var ALLOCATION_DURATION_SECONDS = 60 * 60;
 var ProxyError = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -11894,11 +11894,7 @@ async function safeDoHandler(allocationId, request, log) {
   }
 }
 async function doHandler(allocationId, request, log) {
-  const durationSeconds = request.durationSeconds ?? MAX_ALLOCATION_DURATION_SECONDS;
-  if (durationSeconds > MAX_ALLOCATION_DURATION_SECONDS) {
-    throw new ProxyError(400, `Maximum allocation duration is ${MAX_ALLOCATION_DURATION_SECONDS} seconds`);
-  }
-  const timeoutDate = new Date(Date.now() + 1e3 * durationSeconds);
+  const timeoutDate = new Date(Date.now() + 1e3 * ALLOCATION_DURATION_SECONDS);
   log.info(`Acquiring environment from pool '${request.pool}'`);
   const environment = await acquireEnvironment(allocationId, request.pool);
   log.info(`Starting allocation of 'aws://${environment.account}/${environment.region}'`);
@@ -11906,7 +11902,7 @@ async function doHandler(allocationId, request, log) {
   log.info(`Grabbing credentials to aws://${environment.account}/${environment.region} using role: ${environment.adminRoleArn}`);
   const credentials = await grabCredentials(allocationId, environment);
   log.info("Allocation started successfully");
-  const response = { id: allocationId, environment, credentials, durationSeconds };
+  const response = { id: allocationId, environment, credentials };
   log.info(`Scheduling allocation timeout to ${timeoutDate}`);
   await clients.scheduler.scheduleAllocationTimeout({
     allocationId,
@@ -12254,7 +12250,7 @@ if (require.main !== module) {
 }
 
 // src/deallocate/deallocate.lambda.ts
-var MAX_CLEANUP_TIMEOUT_SECONDS = 60 * 60;
+var CLEANUP_TIMEOUT_SECONDS = 60 * 60;
 var ProxyError2 = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -12285,11 +12281,7 @@ async function safeDoHandler2(allocationId, request, log) {
 }
 async function doHandler3(allocationId, request, log) {
   try {
-    const cleanupDurationSeconds = request.cleanupDurationSeconds ?? MAX_CLEANUP_TIMEOUT_SECONDS;
-    if (cleanupDurationSeconds > MAX_CLEANUP_TIMEOUT_SECONDS) {
-      throw new ProxyError2(400, `Maximum cleanup timeout is ${MAX_CLEANUP_TIMEOUT_SECONDS} seconds`);
-    }
-    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * cleanupDurationSeconds);
+    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * CLEANUP_TIMEOUT_SECONDS);
     log.info(`Ending allocation with outcome: ${request.outcome}`);
     const allocation = await endAllocation(allocationId, request.outcome);
     log.info(`Scheduling timeout for cleanup of environment 'aws://${allocation.account}/${allocation.region}' to ${cleanupTimeoutDate}`);
@@ -12302,13 +12294,13 @@ async function doHandler3(allocationId, request, log) {
     });
     log.info(`Starting cleanup of 'aws://${allocation.account}/${allocation.region}'`);
     await clients3.environments.cleaning(allocationId, allocation.account, allocation.region);
-    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: cleanupDurationSeconds });
+    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: CLEANUP_TIMEOUT_SECONDS });
     log.info(`Successfully started cleanup task: ${taskInstanceArn}`);
-    return success2({ cleanupDurationSeconds });
+    return success2();
   } catch (e) {
     if (e instanceof AllocationAlreadyEndedError) {
       log.info(`Returning success because: ${e.message}`);
-      return success2({ cleanupDurationSeconds: -1 });
+      return success2();
     }
     throw e;
   }
@@ -12337,8 +12329,8 @@ async function endAllocation(id, outcome) {
     throw e;
   }
 }
-function success2(body) {
-  return { statusCode: 200, body: JSON.stringify(body) };
+function success2() {
+  return { statusCode: 200, body: JSON.stringify({}) };
 }
 function failure2(e) {
   const statusCode = e instanceof ProxyError2 ? e.statusCode : 500;
@@ -12745,29 +12737,48 @@ var Runner = class _Runner {
   }
 };
 
-// test/integ/deallocate/assert.lambda.ts
+// test/integ/cleanup-timeout/assert.lambda.ts
 var clients7 = RuntimeClients.getOrCreate();
 async function handler6(_) {
-  await Runner.assert("creates-right-resources", async (session) => {
-    const allocateResponse = await session.runtime.allocate({ pool: "release", requester: "test" });
-    const allocationResponseBody = JSON.parse(allocateResponse.body);
-    const account = allocationResponseBody.environment.account;
-    const region = allocationResponseBody.environment.region;
-    const deallocateResponse = await session.runtime.deallocate(allocationResponseBody.id, { outcome: "success" });
-    assert2.strictEqual(deallocateResponse.status, 200);
+  await Runner.assert("marks-dirty-when-environment-is-still-cleaning", async (session) => {
+    const response = await session.runtime.allocate({ pool: "release", requester: "test" });
+    const body = JSON.parse(response.body);
+    const account = body.environment.account;
+    const region = body.environment.region;
+    await clients7.environments.cleaning(body.id, account, region);
+    await session.runtime.cleanupTimeout({ allocationId: body.id, account, region });
     const environment = await clients7.environments.get(account, region);
-    assert2.strictEqual(environment.status, "cleaning");
-    const allocation = await clients7.allocations.get(allocationResponseBody.id);
-    assert2.ok(allocation.end);
-    const cleanupTimeoutSchedule = await session.fetchCleanupTimeoutSchedule(allocationResponseBody.id);
-    assert2.ok(cleanupTimeoutSchedule);
+    assert2.strictEqual(environment.status, "dirty");
   });
-  await Runner.assert("is-idempotent", async (session) => {
-    const allocateResponse = await session.runtime.allocate({ pool: "release", requester: "test" });
-    const allocationResponseBody = JSON.parse(allocateResponse.body);
-    await session.runtime.deallocate(allocationResponseBody.id, { outcome: "success" });
-    const secondDeallocateResponse = await session.runtime.deallocate(allocationResponseBody.id, { outcome: "success" });
-    assert2.strictEqual(secondDeallocateResponse.status, 200);
+  await Runner.assert("no-ops-when-environment-is-already-released", async (session) => {
+    const response = await session.runtime.allocate({ pool: "release", requester: "test" });
+    const body = JSON.parse(response.body);
+    const account = body.environment.account;
+    const region = body.environment.region;
+    await clients7.environments.cleaning(body.id, account, region);
+    await clients7.environments.release(body.id, account, region);
+    await session.runtime.cleanupTimeout({ allocationId: body.id, account, region });
+    try {
+      await clients7.environments.get(account, region);
+      assert2.fail("expected environment to be deleted");
+    } catch (err) {
+      assert2.strictEqual(err.constructor.name, "EnvironmentNotFound");
+    }
+  });
+  await Runner.assert("no-ops-when-environment-has-been-reallocated", async (session) => {
+    const allocateResponse1 = await session.runtime.allocate({ pool: "release", requester: "test" });
+    const body = JSON.parse(allocateResponse1.body);
+    const account = body.environment.account;
+    const region = body.environment.region;
+    const allocationId = body.id;
+    await clients7.environments.cleaning(allocationId, account, region);
+    await clients7.environments.release(allocationId, account, region);
+    const allocateResponse2 = await session.runtime.allocate({ pool: "release", requester: "test" });
+    const allocateResponseBody2 = JSON.parse(allocateResponse2.body);
+    await session.runtime.cleanupTimeout({ allocationId, account, region });
+    const environment = await clients7.environments.get(account, region);
+    assert2.strictEqual(environment.status, "in-use");
+    assert2.strictEqual(environment.allocation, allocateResponseBody2.id);
   });
   return SUCCESS_PAYLOAD;
 }

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.assets.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "9fe8a832b4f8dd4e7dc72690f5e057019b93fd81309aa28f447ea6fcc615fdec": {
+    "f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7": {
       "source": {
-        "path": "asset.9fe8a832b4f8dd4e7dc72690f5e057019b93fd81309aa28f447ea6fcc615fdec",
+        "path": "asset.f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9fe8a832b4f8dd4e7dc72690f5e057019b93fd81309aa28f447ea6fcc615fdec.zip",
+          "objectKey": "f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "667896807d34e6c108953cb6f269e36e7ddd48af5d3880a81c5c011dad2344f1": {
+    "f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e": {
       "source": {
         "path": "atmosphere-integ-cleanup-timeout-assertions.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "667896807d34e6c108953cb6f269e36e7ddd48af5d3880a81c5c011dad2344f1.json",
+          "objectKey": "f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.template.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.template.json
@@ -107,7 +107,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "9fe8a832b4f8dd4e7dc72690f5e057019b93fd81309aa28f447ea6fcc615fdec.zip"
+     "S3Key": "f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7.zip"
     },
     "Description": "test/integ/cleanup-timeout/assert.lambda.ts",
     "Environment": {
@@ -236,7 +236,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682512244"
+    "salt": "1738692942764"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.assets.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "1ca4ced192965f9fa84324474f682c01dfa1acad485c94e6f66a910d299ec708": {
+    "9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4": {
       "source": {
         "path": "atmosphere-integ-cleanup-timeout.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "1ca4ced192965f9fa84324474f682c01dfa1acad485c94e6f66a910d299ec708.json",
+          "objectKey": "9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.template.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/manifest.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/1ca4ced192965f9fa84324474f682c01dfa1acad485c94e6f66a910d299ec708.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -571,15 +571,6 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
-        ],
-        "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995",
-            "trace": [
-              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
-            ]
-          }
         ]
       },
       "displayName": "atmosphere-integ-cleanup-timeout"
@@ -601,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/667896807d34e6c108953cb6f269e36e7ddd48af5d3880a81c5c011dad2344f1.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/tree.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3970,7 +3970,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "9fe8a832b4f8dd4e7dc72690f5e057019b93fd81309aa28f447ea6fcc615fdec.zip"
+                      "s3Key": "f1a75434d8e70cd47ecdadc321dd960687eb2e13693eeba17e817efa5145a2b7.zip"
                     },
                     "description": "test/integ/cleanup-timeout/assert.lambda.ts",
                     "environment": {

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/asset.699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e/index.js
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/asset.699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e/index.js
@@ -11865,7 +11865,7 @@ var Logger = class {
 };
 
 // src/allocate/allocate.lambda.ts
-var MAX_ALLOCATION_DURATION_SECONDS = 60 * 60;
+var ALLOCATION_DURATION_SECONDS = 60 * 60;
 var ProxyError = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -11895,11 +11895,7 @@ async function safeDoHandler(allocationId, request, log) {
   }
 }
 async function doHandler(allocationId, request, log) {
-  const durationSeconds = request.durationSeconds ?? MAX_ALLOCATION_DURATION_SECONDS;
-  if (durationSeconds > MAX_ALLOCATION_DURATION_SECONDS) {
-    throw new ProxyError(400, `Maximum allocation duration is ${MAX_ALLOCATION_DURATION_SECONDS} seconds`);
-  }
-  const timeoutDate = new Date(Date.now() + 1e3 * durationSeconds);
+  const timeoutDate = new Date(Date.now() + 1e3 * ALLOCATION_DURATION_SECONDS);
   log.info(`Acquiring environment from pool '${request.pool}'`);
   const environment = await acquireEnvironment(allocationId, request.pool);
   log.info(`Starting allocation of 'aws://${environment.account}/${environment.region}'`);
@@ -11907,7 +11903,7 @@ async function doHandler(allocationId, request, log) {
   log.info(`Grabbing credentials to aws://${environment.account}/${environment.region} using role: ${environment.adminRoleArn}`);
   const credentials = await grabCredentials(allocationId, environment);
   log.info("Allocation started successfully");
-  const response = { id: allocationId, environment, credentials, durationSeconds };
+  const response = { id: allocationId, environment, credentials };
   log.info(`Scheduling allocation timeout to ${timeoutDate}`);
   await clients.scheduler.scheduleAllocationTimeout({
     allocationId,
@@ -12255,7 +12251,7 @@ if (require.main !== module) {
 }
 
 // src/deallocate/deallocate.lambda.ts
-var MAX_CLEANUP_TIMEOUT_SECONDS = 60 * 60;
+var CLEANUP_TIMEOUT_SECONDS = 60 * 60;
 var ProxyError2 = class extends Error {
   constructor(statusCode, message) {
     super(`${statusCode}: ${message}`);
@@ -12286,11 +12282,7 @@ async function safeDoHandler2(allocationId, request, log) {
 }
 async function doHandler3(allocationId, request, log) {
   try {
-    const cleanupDurationSeconds = request.cleanupDurationSeconds ?? MAX_CLEANUP_TIMEOUT_SECONDS;
-    if (cleanupDurationSeconds > MAX_CLEANUP_TIMEOUT_SECONDS) {
-      throw new ProxyError2(400, `Maximum cleanup timeout is ${MAX_CLEANUP_TIMEOUT_SECONDS} seconds`);
-    }
-    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * cleanupDurationSeconds);
+    const cleanupTimeoutDate = new Date(Date.now() + 1e3 * CLEANUP_TIMEOUT_SECONDS);
     log.info(`Ending allocation with outcome: ${request.outcome}`);
     const allocation = await endAllocation(allocationId, request.outcome);
     log.info(`Scheduling timeout for cleanup of environment 'aws://${allocation.account}/${allocation.region}' to ${cleanupTimeoutDate}`);
@@ -12303,13 +12295,13 @@ async function doHandler3(allocationId, request, log) {
     });
     log.info(`Starting cleanup of 'aws://${allocation.account}/${allocation.region}'`);
     await clients3.environments.cleaning(allocationId, allocation.account, allocation.region);
-    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: cleanupDurationSeconds });
+    const taskInstanceArn = await clients3.cleanup.start({ allocation, timeoutSeconds: CLEANUP_TIMEOUT_SECONDS });
     log.info(`Successfully started cleanup task: ${taskInstanceArn}`);
-    return success2({ cleanupDurationSeconds });
+    return success2();
   } catch (e) {
     if (e instanceof AllocationAlreadyEndedError) {
       log.info(`Returning success because: ${e.message}`);
-      return success2({ cleanupDurationSeconds: -1 });
+      return success2();
     }
     throw e;
   }
@@ -12338,8 +12330,8 @@ async function endAllocation(id, outcome) {
     throw e;
   }
 }
-function success2(body) {
-  return { statusCode: 200, body: JSON.stringify(body) };
+function success2() {
+  return { statusCode: 200, body: JSON.stringify({}) };
 }
 function failure2(e) {
   const statusCode = e instanceof ProxyError2 ? e.statusCode : 500;

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.assets.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "49f2fc7b322a41fb287bd12ad20f9ed9d7d507575bc3a23908a08e942c40013b": {
+    "699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e": {
       "source": {
-        "path": "asset.49f2fc7b322a41fb287bd12ad20f9ed9d7d507575bc3a23908a08e942c40013b",
+        "path": "asset.699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "49f2fc7b322a41fb287bd12ad20f9ed9d7d507575bc3a23908a08e942c40013b.zip",
+          "objectKey": "699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -40,7 +40,7 @@
         }
       }
     },
-    "f9f51510d8916a0ee457e16f2300cec3823f61d71355fd486030783927a380fe": {
+    "66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f": {
       "source": {
         "path": "atmosphere-integ-cleanup-assertions.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f9f51510d8916a0ee457e16f2300cec3823f61d71355fd486030783927a380fe.json",
+          "objectKey": "66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.template.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.template.json
@@ -107,7 +107,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "49f2fc7b322a41fb287bd12ad20f9ed9d7d507575bc3a23908a08e942c40013b.zip"
+     "S3Key": "699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e.zip"
     },
     "Description": "test/integ/cleanup/assert.lambda.ts",
     "Environment": {
@@ -236,7 +236,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682512245"
+    "salt": "1738692942768"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.assets.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "6686ff59b5f2deb36e518d87be80d927da89bf96f016ffcc1acae828db125a95": {
+    "d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176": {
       "source": {
         "path": "atmosphere-integ-cleanup.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6686ff59b5f2deb36e518d87be80d927da89bf96f016ffcc1acae828db125a95.json",
+          "objectKey": "d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.template.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/manifest.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6686ff59b5f2deb36e518d87be80d927da89bf96f016ffcc1acae828db125a95.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -571,15 +571,6 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
-        ],
-        "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995",
-            "trace": [
-              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
-            ]
-          }
         ]
       },
       "displayName": "atmosphere-integ-cleanup"
@@ -601,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f9f51510d8916a0ee457e16f2300cec3823f61d71355fd486030783927a380fe.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/tree.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/tree.json
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3970,7 +3970,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "49f2fc7b322a41fb287bd12ad20f9ed9d7d507575bc3a23908a08e942c40013b.zip"
+                      "s3Key": "699c00b2b638607e9cfd554ddcb78f6305731210ca8a812b7b2f5656a4e2834e.zip"
                     },
                     "description": "test/integ/cleanup/assert.lambda.ts",
                     "environment": {

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.assets.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "cbfcea80fcd4a5071459855fe945882173749a996a911f005070e30f7752f506": {
+    "b5c1253994cc3f0bae90d34eebcecc5b9c5e089bf3d9a6df8b423bc0d6506050": {
       "source": {
-        "path": "asset.cbfcea80fcd4a5071459855fe945882173749a996a911f005070e30f7752f506",
+        "path": "asset.b5c1253994cc3f0bae90d34eebcecc5b9c5e089bf3d9a6df8b423bc0d6506050",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "cbfcea80fcd4a5071459855fe945882173749a996a911f005070e30f7752f506.zip",
+          "objectKey": "b5c1253994cc3f0bae90d34eebcecc5b9c5e089bf3d9a6df8b423bc0d6506050.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "86c4ec3b87dff6df773cdc24917f94214043991acadb4eb8cb2856246add832c": {
+    "7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e": {
       "source": {
         "path": "atmosphere-integ-deallocate-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "86c4ec3b87dff6df773cdc24917f94214043991acadb4eb8cb2856246add832c.json",
+          "objectKey": "7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.template.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.template.json
@@ -50,7 +50,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "cbfcea80fcd4a5071459855fe945882173749a996a911f005070e30f7752f506.zip"
+     "S3Key": "b5c1253994cc3f0bae90d34eebcecc5b9c5e089bf3d9a6df8b423bc0d6506050.zip"
     },
     "Description": "test/integ/deallocate/assert.lambda.ts",
     "Environment": {
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682512242"
+    "salt": "1738692942758"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.assets.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "52ad1251c0b3f6857b9981fe643160eb074cb32fe8327205ecad9c86e1f89407": {
+    "4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811": {
       "source": {
         "path": "atmosphere-integ-deallocate.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "52ad1251c0b3f6857b9981fe643160eb074cb32fe8327205ecad9c86e1f89407.json",
+          "objectKey": "4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.template.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/manifest.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/52ad1251c0b3f6857b9981fe643160eb074cb32fe8327205ecad9c86e1f89407.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -571,15 +571,6 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
-        ],
-        "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef617c1338fea6cd9a98c3bd22320995",
-            "trace": [
-              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
-            ]
-          }
         ]
       },
       "displayName": "atmosphere-integ-deallocate"
@@ -601,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/86c4ec3b87dff6df773cdc24917f94214043991acadb4eb8cb2856246add832c.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/tree.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
-                    "path": "atmosphere-integ-deallocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                    "path": "atmosphere-integ-deallocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
-                    "path": "atmosphere-integ-deallocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                    "path": "atmosphere-integ-deallocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3895,7 +3895,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "cbfcea80fcd4a5071459855fe945882173749a996a911f005070e30f7752f506.zip"
+                      "s3Key": "b5c1253994cc3f0bae90d34eebcecc5b9c5e089bf3d9a6df8b423bc0d6506050.zip"
                     },
                     "description": "test/integ/deallocate/assert.lambda.ts",
                     "environment": {

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e": {
+    "1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45": {
       "source": {
         "path": "atmosphere-integ-dev-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e.json",
+          "objectKey": "1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "39.0.0",
   "files": {
-    "7f7413705dc407c53ba3cffa2e028177ad30a62487f4a39129dc1555dceeb50b": {
+    "a9626924bbab33364c558e3b8e6fb9dae676c6cf840d74feac83362b7f01c2cf": {
       "source": {
-        "path": "asset.7f7413705dc407c53ba3cffa2e028177ad30a62487f4a39129dc1555dceeb50b",
+        "path": "asset.a9626924bbab33364c558e3b8e6fb9dae676c6cf840d74feac83362b7f01c2cf",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7f7413705dc407c53ba3cffa2e028177ad30a62487f4a39129dc1555dceeb50b.zip",
+          "objectKey": "a9626924bbab33364c558e3b8e6fb9dae676c6cf840d74feac83362b7f01c2cf.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "9e4787375373997480bce6d758a609470aa5b9d546ee46da39a9a8cc8646ad87": {
+    "a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e": {
       "source": {
         "path": "atmosphere-integ-dev-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9e4787375373997480bce6d758a609470aa5b9d546ee46da39a9a8cc8646ad87.json",
+          "objectKey": "a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738691213370"
+    "salt": "1738692942757"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
@@ -50,7 +50,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "7f7413705dc407c53ba3cffa2e028177ad30a62487f4a39129dc1555dceeb50b.zip"
+     "S3Key": "a9626924bbab33364c558e3b8e6fb9dae676c6cf840d74feac83362b7f01c2cf.zip"
     },
     "Description": "test/integ/dev/assert.lambda.ts",
     "Environment": {
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738682512242"
+    "salt": "1738691213370"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.assets.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.assets.json
@@ -92,33 +92,33 @@
         }
       }
     },
-    "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5": {
+    "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0": {
       "source": {
-        "path": "asset.33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.lambda",
+        "path": "asset.37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip",
+          "objectKey": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c": {
+    "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef": {
       "source": {
-        "path": "asset.bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.lambda",
+        "path": "asset.07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip",
+          "objectKey": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "18ec28f99720d535f9fe3d5c7e2dafe6104aac8639a96d5eb0897d07decec871": {
+    "b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7": {
       "source": {
         "path": "atmosphere-integ-dev.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "18ec28f99720d535f9fe3d5c7e2dafe6104aac8639a96d5eb0897d07decec871.json",
+          "objectKey": "b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.template.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.template.json
@@ -1520,7 +1520,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+     "S3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
     },
     "Description": "src/allocate/allocate.lambda.ts",
     "Environment": {
@@ -1716,7 +1716,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+     "S3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
     },
     "Description": "src/deallocate/deallocate.lambda.ts",
     "Environment": {

--- a/test/integ/dev/integ.dev.ts.snapshot/manifest.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/18ec28f99720d535f9fe3d5c7e2dafe6104aac8639a96d5eb0897d07decec871.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -592,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/9e4787375373997480bce6d758a609470aa5b9d546ee46da39a9a8cc8646ad87.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/dev/integ.dev.ts.snapshot/manifest.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/manifest.json
@@ -592,7 +592,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/a9400adb823db10412c08ccaff28448db26c522beb7ef9b4f3c7c73fab07111e.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/dev/integ.dev.ts.snapshot/tree.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"

--- a/test/integ/dev/integ.dev.ts.snapshot/tree.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2404,7 +2404,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "33174d1cdb83f3914597f3c2dd8251feff2d32ef50582f8dc9fc2cd0e6fa37c5.zip"
+                              "s3Key": "37e3c66e28149d7cff384ce6917d5bace794f64d0136160a483af6d3965753f0.zip"
                             },
                             "description": "src/allocate/allocate.lambda.ts",
                             "environment": {
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2696,7 +2696,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "bd8d4f46c0209934806dc1d20c30509f6da94bdc70dc8cc87486b7dca0c8075c.zip"
+                              "s3Key": "07c22755420225be62e4790b84e4501800b107cf6d663bf892455bbbebfcfcef.zip"
                             },
                             "description": "src/deallocate/deallocate.lambda.ts",
                             "environment": {
@@ -3895,7 +3895,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "7f7413705dc407c53ba3cffa2e028177ad30a62487f4a39129dc1555dceeb50b.zip"
+                      "s3Key": "a9626924bbab33364c558e3b8e6fb9dae676c6cf840d74feac83362b7f01c2cf.zip"
                     },
                     "description": "test/integ/dev/assert.lambda.ts",
                     "environment": {


### PR DESCRIPTION
It was originally added because integ tests require it, they don't anymore.