### PR TITLE
fix: release is not allowed via cross account role

### DIFF
--- a/src/api/endpoint.ts
+++ b/src/api/endpoint.ts
@@ -73,7 +73,7 @@ export class Endpoint extends Construct {
     const effect = props.allowedPrincipals ? iam.Effect.ALLOW: iam.Effect.DENY;
     const resources = props.allowedPrincipals ? [
       'execute-api:/prod/POST/allocations',
-      'execute-api:/prod/DELETE/allocations/{id}',
+      'execute-api:/prod/DELETE/allocations/*',
     ] : ['*'];
 
     // Create the API Gateway

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.assets.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac": {
+    "18ee91e00d4bb232be783258b1a858b9382684ef58f450720fad11de3e8543b1": {
       "source": {
         "path": "atmosphere-integ-allocate-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac.json",
+          "objectKey": "18ee91e00d4bb232be783258b1a858b9382684ef58f450720fad11de3e8543b1.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.template.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate-assertions.template.json
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692955183"
+    "salt": "1738704809682"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.assets.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94": {
+    "ebc4ca5a628ce6b6c83b76724187ff1e48329640246bac8d56b8726179a33cf4": {
       "source": {
         "path": "atmosphere-integ-allocate.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94.json",
+          "objectKey": "ebc4ca5a628ce6b6c83b76724187ff1e48329640246bac8d56b8726179a33cf4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.template.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/atmosphere-integ-allocate.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/allocate/integ.allocate.ts.snapshot/manifest.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/50aa7ded82eb637d4f2861a9c677279e185ea3636f074f58378aef6ae40fba94.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/ebc4ca5a628ce6b6c83b76724187ff1e48329640246bac8d56b8726179a33cf4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-allocate/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-allocate/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-allocate"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3413f196a51864e2d0e0efc54fb863feb8c825d8e20d4fa255cc12ad4adb4cac.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/18ee91e00d4bb232be783258b1a858b9382684ef58f450720fad11de3e8543b1.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/allocate/integ.allocate.ts.snapshot/tree.json
+++ b/test/integ/allocate/integ.allocate.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
-                    "path": "atmosphere-integ-allocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.4]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.4]}eu-central-1",
+                    "path": "atmosphere-integ-allocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.4]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
-                    "path": "atmosphere-integ-allocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.4]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.4]}eu-central-1",
+                    "path": "atmosphere-integ-allocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.4]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.assets.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3": {
+    "84c2a6dc8c7ac3d2b3817ce73829280515677dff793371d7ef0b30ae752f2ca3": {
       "source": {
         "path": "atmosphere-integ-allocation-timeout-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3.json",
+          "objectKey": "84c2a6dc8c7ac3d2b3817ce73829280515677dff793371d7ef0b30ae752f2ca3.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.template.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout-assertions.template.json
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692955183"
+    "salt": "1738704809680"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.assets.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb": {
+    "0c6c84b2c0ac05f848f8cccd07bbeb3d634f2b4f1bd200872f3e29bdf4cca360": {
       "source": {
         "path": "atmosphere-integ-allocation-timeout.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb.json",
+          "objectKey": "0c6c84b2c0ac05f848f8cccd07bbeb3d634f2b4f1bd200872f3e29bdf4cca360.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.template.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/atmosphere-integ-allocation-timeout.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/manifest.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0cb60343afde3d129030176c10e15a05ac133531237d0e7baeb34c80ff0637cb.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0c6c84b2c0ac05f848f8cccd07bbeb3d634f2b4f1bd200872f3e29bdf4cca360.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-allocation-timeout/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-allocation-timeout/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-allocation-timeout"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/52a91b5d6e3c7bd7fc6304e279efac5651c654314c3e87b73a2c06a07d4d41d3.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/84c2a6dc8c7ac3d2b3817ce73829280515677dff793371d7ef0b30ae752f2ca3.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/tree.json
+++ b/test/integ/allocation-timeout/integ.allocation-timeout.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.8]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.8]}eu-central-1",
-                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.8]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                    "path": "atmosphere-integ-allocation-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.assets.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.assets.json
@@ -40,7 +40,7 @@
         }
       }
     },
-    "f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e": {
+    "29a0687089c008b7187ebc7869734070a928d27939d6eebf428f5b7c1d9d3761": {
       "source": {
         "path": "atmosphere-integ-cleanup-timeout-assertions.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e.json",
+          "objectKey": "29a0687089c008b7187ebc7869734070a928d27939d6eebf428f5b7c1d9d3761.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.template.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout-assertions.template.json
@@ -236,7 +236,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692942764"
+    "salt": "1738704797523"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.assets.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4": {
+    "8ea588919df489ab67bddba3ede108bcb0f6a7e067adeb25e61e1158f4ee1753": {
       "source": {
         "path": "atmosphere-integ-cleanup-timeout.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4.json",
+          "objectKey": "8ea588919df489ab67bddba3ede108bcb0f6a7e067adeb25e61e1158f4ee1753.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.template.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/atmosphere-integ-cleanup-timeout.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/manifest.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/9a78e6d717976f56b4699f5ce0ad3503f378a08362b5e58d9ac9ebbfb1e1c5b4.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/8ea588919df489ab67bddba3ede108bcb0f6a7e067adeb25e61e1158f4ee1753.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-cleanup-timeout/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-cleanup-timeout/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-cleanup-timeout"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f939edf5889f385e07bf57715eb3d60927b61030858582ed5b6cda704d328f5e.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/29a0687089c008b7187ebc7869734070a928d27939d6eebf428f5b7c1d9d3761.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/tree.json
+++ b/test/integ/cleanup-timeout/integ.cleanup-timeout.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.3]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.3]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.3]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.6]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.6]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.6]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.3]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.3]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup-timeout/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.3]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.assets.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.assets.json
@@ -40,7 +40,7 @@
         }
       }
     },
-    "66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f": {
+    "f55161741c82a84dfa15ea3ac90ca3fe7c90f913f0ee0255cd5d57ffac98c5be": {
       "source": {
         "path": "atmosphere-integ-cleanup-assertions.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f.json",
+          "objectKey": "f55161741c82a84dfa15ea3ac90ca3fe7c90f913f0ee0255cd5d57ffac98c5be.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.template.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup-assertions.template.json
@@ -236,7 +236,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692942768"
+    "salt": "1738704797524"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.assets.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176": {
+    "5ffaffee8460ee16d904198774488c8e7ac6628a7cfc5bcf5978c0bddb6601f3": {
       "source": {
         "path": "atmosphere-integ-cleanup.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176.json",
+          "objectKey": "5ffaffee8460ee16d904198774488c8e7ac6628a7cfc5bcf5978c0bddb6601f3.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.template.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/atmosphere-integ-cleanup.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/manifest.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d5a87a4afddfb78d0f175d23a3bb240f3bfcbe7269e8199746fb46caf48df176.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5ffaffee8460ee16d904198774488c8e7ac6628a7cfc5bcf5978c0bddb6601f3.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-cleanup/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-cleanup/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-cleanup"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/66a68cf075b18cba2925cb63a8e83a3522107afd56f4116c4bfd07a42d02a12f.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f55161741c82a84dfa15ea3ac90ca3fe7c90f913f0ee0255cd5d57ffac98c5be.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/cleanup/integ.cleanup.ts.snapshot/tree.json
+++ b/test/integ/cleanup/integ.cleanup.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.0]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.0]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.0]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.0]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.0]}eu-central-1",
-                    "path": "atmosphere-integ-cleanup/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.0]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                    "path": "atmosphere-integ-cleanup/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.assets.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e": {
+    "c9da2b1d86ff258960a0d584a4a7b1c84ed0f627ed509677c644ac8a5908312f": {
       "source": {
         "path": "atmosphere-integ-deallocate-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e.json",
+          "objectKey": "c9da2b1d86ff258960a0d584a4a7b1c84ed0f627ed509677c644ac8a5908312f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.template.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate-assertions.template.json
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692942758"
+    "salt": "1738704797522"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.assets.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811": {
+    "fe173ccdb147d2a5418f516064ed44eec7cbe442014143ed6eb17a4c2eb49f6c": {
       "source": {
         "path": "atmosphere-integ-deallocate.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811.json",
+          "objectKey": "fe173ccdb147d2a5418f516064ed44eec7cbe442014143ed6eb17a4c2eb49f6c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.template.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/atmosphere-integ-deallocate.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/manifest.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4acdce843348978b6497a319c6c0d0addef63f50e1f6be1d9a9854fdf18a7811.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/fe173ccdb147d2a5418f516064ed44eec7cbe442014143ed6eb17a4c2eb49f6c.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-deallocate/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-deallocate/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-deallocate"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7c0b637a04dba0ee762c5dbcace58e4ce0b127aeea284d5bed0c729ed873698e.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/c9da2b1d86ff258960a0d584a4a7b1c84ed0f627ed509677c644ac8a5908312f.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/deallocate/integ.deallocate.ts.snapshot/tree.json
+++ b/test/integ/deallocate/integ.deallocate.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
-                    "path": "atmosphere-integ-deallocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                    "path": "atmosphere-integ-deallocate/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.5]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.5]}eu-central-1",
-                    "path": "atmosphere-integ-deallocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.5]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.2]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.2]}eu-central-1",
+                    "path": "atmosphere-integ-deallocate/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.2]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.assets.json
@@ -27,7 +27,7 @@
         }
       }
     },
-    "1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45": {
+    "a1d9752e4003ef8e7a942fb5c69dc8cf73726d706664c49825bb47a3b69aa0d2": {
       "source": {
         "path": "atmosphere-integ-dev-assertions.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45.json",
+          "objectKey": "a1d9752e4003ef8e7a942fb5c69dc8cf73726d706664c49825bb47a3b69aa0d2.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev-assertions.template.json
@@ -174,7 +174,7 @@
      }
     },
     "flattenResponse": "false",
-    "salt": "1738692942757"
+    "salt": "1738704797522"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.assets.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.assets.json
@@ -118,7 +118,7 @@
         }
       }
     },
-    "b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7": {
+    "6a129fb58626073caf2793156995409ac65e72afecbd99e307c5551d2ec8c46d": {
       "source": {
         "path": "atmosphere-integ-dev.template.json",
         "packaging": "file"
@@ -126,7 +126,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7.json",
+          "objectKey": "6a129fb58626073caf2793156995409ac65e72afecbd99e307c5551d2ec8c46d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.template.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/atmosphere-integ-dev.template.json
@@ -1819,7 +1819,7 @@
         }
        },
        "Resource": [
-        "execute-api:/prod/DELETE/allocations/{id}",
+        "execute-api:/prod/DELETE/allocations/*",
         "execute-api:/prod/POST/allocations"
        ]
       }
@@ -1830,7 +1830,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": {
+  "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
     "Description": "RESTful endpoint for the Atmosphere service",
@@ -1851,7 +1851,7 @@
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
     "DeploymentId": {
-     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+     "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
     },
     "RestApiId": {
      "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/integ/dev/integ.dev.ts.snapshot/manifest.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b5bf239f9e1c994bc8fc870003297eb5f4779dc8355ef41bfaa1fc75367f4bd7.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6a129fb58626073caf2793156995409ac65e72afecbd99e307c5551d2ec8c46d.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -325,7 +325,7 @@
         "/atmosphere-integ-dev/Atmosphere/Endpoint/Api/Deployment/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
           }
         ],
         "/atmosphere-integ-dev/Atmosphere/Endpoint/Api/DeploymentStage.prod/Resource": [
@@ -571,6 +571,15 @@
             "type": "aws:cdk:logicalId",
             "data": "CheckBootstrapVersion"
           }
+        ],
+        "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
         ]
       },
       "displayName": "atmosphere-integ-dev"
@@ -592,7 +601,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/1fae436a366c21bddbcc851f3d523c2984ee8f4bb180f7586b5ea6fb9daf4c45.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/a1d9752e4003ef8e7a942fb5c69dc8cf73726d706664c49825bb47a3b69aa0d2.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/dev/integ.dev.ts.snapshot/tree.json
+++ b/test/integ/dev/integ.dev.ts.snapshot/tree.json
@@ -1489,9 +1489,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.4]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.4]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Cleanup/AdminRole${Token[AWS.AccountId.4]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2468,9 +2468,9 @@
                       "version": "2.177.0"
                     }
                   },
-                  "AdminRole${Token[AWS.AccountId.7]}eu-central-1": {
-                    "id": "AdminRole${Token[AWS.AccountId.7]}eu-central-1",
-                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.7]}eu-central-1",
+                  "AdminRole${Token[AWS.AccountId.4]}eu-central-1": {
+                    "id": "AdminRole${Token[AWS.AccountId.4]}eu-central-1",
+                    "path": "atmosphere-integ-dev/Atmosphere/Allocate/AdminRole${Token[AWS.AccountId.4]}eu-central-1",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
                       "version": "2.177.0"
@@ -2821,7 +2821,7 @@
                                     }
                                   },
                                   "Resource": [
-                                    "execute-api:/prod/DELETE/allocations/{id}",
+                                    "execute-api:/prod/DELETE/allocations/*",
                                     "execute-api:/prod/POST/allocations"
                                   ]
                                 }
@@ -2873,7 +2873,7 @@
                               "aws:cdk:cloudformation:type": "AWS::ApiGateway::Stage",
                               "aws:cdk:cloudformation:props": {
                                 "deploymentId": {
-                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEd3a90f691daa48e6bec2c149a5daf366"
+                                  "Ref": "AtmosphereEndpointApiDeployment2DF1AFBEef1e60dfb935ea3946af0b04b5eb1de5"
                                 },
                                 "restApiId": {
                                   "Ref": "AtmosphereEndpointApi64E91738"

--- a/test/unit/api/endpoint.test.ts
+++ b/test/unit/api/endpoint.test.ts
@@ -69,7 +69,7 @@ test('can add principals to resource policy', () => {
         },
         Resource: [
           'execute-api:/prod/POST/allocations',
-          'execute-api:/prod/DELETE/allocations/{id}',
+          'execute-api:/prod/DELETE/allocations/*',
         ],
       }],
     },


### PR DESCRIPTION
Doi, `DELETE/allocations/${id}` doesn't mean anything in a resource policy, it should be `DELETE/allocations/*`. Integ tests didn't catch this because they are running all inside the same account. 